### PR TITLE
Add --quick-popup-overlay-z-index CSS variable

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/quickpopup/quick-popup-overlay.js
+++ b/src/main/resources/META-INF/resources/frontend/quickpopup/quick-popup-overlay.js
@@ -13,7 +13,7 @@ class QuickPopupOverlay extends PolymerElement {
         return html `
                 <style>
                     .overlay {
-                        z-index: 200;
+                        z-index: var(--quick-popup-overlay-z-index,200);
                         position: fixed;
                         /*
                         Despite of what the names say, <vaadin-overlay> is just a container


### PR DESCRIPTION
Define z-index as `z-index: var(--quick-popup-overlay-z-index,200);` in order to allow it to be configured by the application.