### PR TITLE
Update pom file

### DIFF
--- a/assembly/MANIFEST.MF
+++ b/assembly/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Vaadin-Package-Version: 1
+Vaadin-Addon: ${project.build.finalName}.${project.packaging}
+Implementation-Vendor: ${organization.name}
+Implementation-Title: ${project.name}
+Implementation-Version: ${project.version}

--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>quick-popup</id>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <!-- Do not use because we must put META-INF/MANIFEST.MF there. -->
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>..</directory>
+            <includes>
+                <include>LICENSE</include>
+                <include>README.md</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>target</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>*.jar</include>
+                <include>*.pdf</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+
+    <files>
+        <!-- This is vaadin.com/directory related manifest needed in the 
+            zip package -->
+        <file>
+            <source>assembly/MANIFEST.MF</source>
+            <outputDirectory>META-INF</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+    </files>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.mdre</groupId>
-    <artifactId>quickpop</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-    <name>quickpop</name>
+    <artifactId>flowquickpopup</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+    <name>flowquickpopup</name>
     <description>QuickPopup component for Vaadin Flow 14.+</description>
 
     <properties>
         <vaadin.version>14.0.13</vaadin.version>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <!-- Replace artifactId with vaadin-core to use only free components -->
-            <artifactId>vaadin</artifactId>
+            <artifactId>vaadin-core</artifactId>
             <exclusions>
                 <!-- Webjars are only needed when running in Vaadin 13 compatibility mode in V14.
                      Your add-on can support npm in the same version mode and V13 compatiblity mode at the same time,


### PR DESCRIPTION
The artifact in Vaadin directory (v1.0.0) is 1840 KB in size (mainly because it contains the component bundles in META-INF/VAADIN, but those bundles are not required when distributing an addon). 

Since I'm not familiar with the gradle configuration for addons, I'm updateing the Maven configuration, so that the addon can be built by executing:
  `mvn install -Pdirectory`
  
I'm also downgrading maven.compiler.target from 11 to 8 (since Java 11 seems not to be a requirement for this addon), and replacing a dependency with `vaadin-core` instead of `vaadin` (since there are no dependencies to commercial components).